### PR TITLE
Handle when serializer has a field that's not on the model

### DIFF
--- a/drf_writable_nested/mixins.py
+++ b/drf_writable_nested/mixins.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from collections import OrderedDict
 
-from django.db.models import ProtectedError
+from django.db.models import ProtectedError, FieldDoesNotExist
 from django.db.models.fields.related import ForeignObjectRel
 from django.utils.translation import ugettext_lazy as _
 from rest_framework import serializers
@@ -16,7 +16,10 @@ class BaseNestedModelSerializer(serializers.ModelSerializer):
         for field_name, field in self.fields.items():
             if field.read_only:
                 continue
-            related_field, direct = self._get_related_field(field)
+            try:
+                related_field, direct = self._get_related_field(field)
+            except FieldDoesNotExist:
+                continue
 
             if isinstance(field, serializers.ListSerializer) and \
                     isinstance(field.child, serializers.ModelSerializer):

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -49,3 +49,17 @@ class UserSerializer(WritableNestedModelSerializer):
     class Meta:
         model = User
         fields = ('pk', 'profile', 'username',)
+
+
+class CustomSerializer(UserSerializer):
+    # Simulate having non-modelfield information on the serializer
+    custom_field = serializers.CharField()
+
+    class Meta(UserSerializer.Meta):
+        fields = UserSerializer.Meta.fields + (
+            'custom_field',
+        )
+
+    def validate(self, attrs):
+        attrs.pop('custom_field', None)
+        return attrs

--- a/tests/test_writable_nested_model_serializer.py
+++ b/tests/test_writable_nested_model_serializer.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 
 from .models import Site, Avatar, User, Profile, AccessKey
-from .serializers import UserSerializer
+from .serializers import UserSerializer, CustomSerializer
 
 
 class WritableNestedModelSerializerTest(TestCase):
@@ -72,6 +72,14 @@ class WritableNestedModelSerializerTest(TestCase):
         serializer.is_valid(raise_exception=True)
         user = serializer.save()
         self.assertFalse(Profile.objects.filter(user=user).exists())
+
+    def test_create_with_custom_field(self):
+        data = self.get_initial_data()
+        data['custom_field'] = 'custom value'
+        serializer = CustomSerializer(data=data)
+        serializer.is_valid(raise_exception=True)
+        user = serializer.save()
+        self.assertIsNotNone(user)
 
     def test_update(self):
         serializer = UserSerializer(data=self.get_initial_data())


### PR DESCRIPTION
Handling cases where serializer has a custom field that is not on the model by catching FieldDoesNotExist. (fixes #4 )